### PR TITLE
Respect min/max bounds in price clustering

### DIFF
--- a/eBay_pricing_v6_5/pricing.py
+++ b/eBay_pricing_v6_5/pricing.py
@@ -42,6 +42,10 @@ def compute_suggestion(rows: List[Dict],
     if not rows:
         return None, None, []
     totals = [r.get("total") for r in rows if r.get("total") is not None]
+    # Honor explicit min/max bounds when computing the cluster window.
+    if min_price is not None or max_price is not None:
+        totals = [t for t in totals if (min_price is None or t >= min_price) and
+                                    (max_price is None or t <= max_price)]
     if not totals:
         return None, None, []
     used: List[Dict] = []

--- a/eBay_pricing_v6_5/tests/test_pricing.py
+++ b/eBay_pricing_v6_5/tests/test_pricing.py
@@ -1,0 +1,17 @@
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from pricing import compute_suggestion
+
+def test_compute_suggestion_respects_min_price():
+    rows = [{"total": t} for t in [10, 11, 12, 100, 101, 102]]
+    total, row, used = compute_suggestion(rows, min_price=50)
+    assert total == 100
+    assert row["total"] == 100
+    assert all(r["total"] >= 50 for r in used)
+
+def test_compute_suggestion_respects_max_price():
+    rows = [{"total": t} for t in [10, 11, 12, 100, 101, 102]]
+    total, row, used = compute_suggestion(rows, max_price=50)
+    assert total == 10
+    assert row["total"] == 10
+    assert all(r["total"] <= 50 for r in used)


### PR DESCRIPTION
## Summary
- ensure compute_suggestion filters totals outside explicit min/max price bounds before clustering
- add regression tests for compute_suggestion min/max handling

## Testing
- `pytest eBay_pricing_v6_5/tests/test_pricing.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689b4073f1cc832db4072d009579bee7