### PR TITLE
Remove redundant absolute-low header comment

### DIFF
--- a/eBay_pricing_v6_5/app.py
+++ b/eBay_pricing_v6_5/app.py
@@ -130,7 +130,6 @@ def index():
                 ebay_exact_total = float(ebay_exact_row["total"])
 
         # ---------- If no exact code+title match, use absolute-low from comp_rows ----------
-        # ---------- If no exact code+title match, use absolute-low from comp_rows ----------
             ebay_abs_row = None
             ebay_abs_total = None
             if comp_rows:


### PR DESCRIPTION
## Summary
- drop duplicated header comment before computing `ebay_abs_row` for absolute-low fallback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689b44804f8c832d856b02cd47d1bf56