### PR TITLE
docs: update title guard threshold comment

### DIFF
--- a/eBay_pricing_v6_5/app.py
+++ b/eBay_pricing_v6_5/app.py
@@ -103,7 +103,7 @@ def index():
         amz_title = (amazon.get("title") if amazon else "") or ""
         amz_toks = tokens(amz_title)
 
-        # ---------- Exact-UPC-first with title guard (>= 0.60) ----------
+        # ---------- Exact-UPC-first with title guard (>= 0.75) ----------
         user_code = _norm_digits(code)
         ebay_exact_row = None
         ebay_exact_total = None


### PR DESCRIPTION
## Summary
- fix exact-UPC title guard comment to note 0.75 threshold

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689b448512b4832da52f0396dc54e290