### PR TITLE
Add tests for choose_and_suggest

### DIFF
--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+# Ensure pricing module is importable
+sys.path.append(str(Path(__file__).resolve().parents[1] / "eBay_pricing_v6_5"))
+from pricing import choose_and_suggest
+
+
+def test_choose_and_suggest_prefers_lower_ebay():
+    """When both competitors are available, the lower eBay price is undercut to $18.99."""
+    result = choose_and_suggest(amazon_total=20.00, ebay_total=19.50)
+    assert result["source"] == "eBay"
+    assert result["suggested"] == 18.99
+
+
+def test_choose_and_suggest_only_amazon():
+    """With only Amazon provided, it is undercut and rounded to $14.99."""
+    result = choose_and_suggest(amazon_total=15.75, ebay_total=None)
+    assert result["suggested"] == 14.99


### PR DESCRIPTION
## Summary
- add regression tests for choose_and_suggest when both Amazon and eBay totals are provided
- add test for suggestions when only Amazon total is available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689b4485e988832db8a12b27ba363208